### PR TITLE
dockerfile: use debian:8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
-FROM debian:latest
+FROM debian:8
 ADD src/ /usr/src/cbng-core
 ADD data/ /usr/src/cbng-data
-RUN apt-get clean
 RUN apt-get update
 
 # Deps


### PR DESCRIPTION
debian:latest is currently debian:9, which fails to compile because of
bad dependency versions.